### PR TITLE
UCC: Update package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ npm-debug.log
 .idea
 .DS_Store
 yarn.lock
+~/.npm

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "main": "./dist/cornerstoneWADOImageLoader.min.js",
   "module": "./dist/cornerstoneWADOImageLoader.min.js",
   "publishConfig": {
+    "cache": "~/.npm",
     "registry": "https://npm.pkg.github.com/"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@DedalusDIIT/cornerstone-wado-image-loader",
+  "name": "@dedalusdiit/cornerstone-wado-image-loader",
   "version": "3.0.7",
   "description": "Cornerstone Image Loader for DICOM WADO-URI and WADO-RS",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-wado-image-loader",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Cornerstone Image Loader for DICOM WADO-URI and WADO-RS",
   "keywords": [
     "DICOM",

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.0.7';
+export default '3.0.8';


### PR DESCRIPTION
# What does this Merge Request do?

Updates package name as npm version 7 and its new package-lock format seem to have issues with capitalization in package versions.

Also, the property 'cache' is added to `publishConfig` in the package.json as otherwise `npm publish` fails with the newest npm version. (https://github.com/npm/cli/issues/2834)

Package with version 2.2.10. is published to reflect these changes.
<!-- Give a brief summary (1-2 sentences) what this Merge Request is about. -->